### PR TITLE
Add App::Cmd support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ push the data to a Datahub instance.
   The password of the Datahub user. Used for OAuth authentication of the Datahub
   endpoint.
 
+# EXAMPLE
+
+```
+dhconveyor transport --importer=Adlib --fixes=myfixes.fix --oimport file_name=adlibexport.xml --datahub=http://datahub/ --ostore oauth_client_id=slightlylesssecretpublicid --ostore oauth_client_secret=supersecretsecretphrase --ostore oauth_password=password1 --ostore oauth_username=admin
+```
+
 # AUTHORS
 
 - Pieter De Praetere <pieter@packed.be>

--- a/README.md
+++ b/README.md
@@ -1,74 +1,94 @@
 # NAME
 [![Build Status](https://travis-ci.org/thedatahub/Datahub-Factory.svg?branch=master)](https://travis-ci.org/thedatahub/Datahub-Factory)
 
-Datahub::Factory - A conveyor belt which transforms data from an input format
-to an output format before pushing it to a Datahub instance.
+Datahub::Factory - A conveyor belt which transports data from a data source to
+a Datahub instance.
 
 # SYNOPSIS
 
-Datahub::Factory consists of two elements: a library (C<Datahub::Factory>) and a conversion script (C<dh-factory.pl>).
+dhconveyor [ARGUMENTS] [OPTIONS]
 
 # DESCRIPTION
 
-Datahub::Factory is a conveyor belt which does two things:
+Datahub::Factory is a command line conveyor belt which automates three tasks:
 
-- Data is converted from an input format to an output format leveraging
-  Catmandu.
-- The output is pushed to an instance of the Datahub.
+- Data is fetched automatically from a local or remote data source.
+- Data is converted to an exchange format.
+- The output is pushed to an operational Datahub instance.
 
-Internally, Datahub::Factory uses Catmandu modules.
+Internally, Datahub::Factory uses Catmandu modules to transform the data, and
+implements the Datahub REST API. Datahub::Factory stitches the transformation
+and push tasks seamlessly together.
 
-# USAGE
+Datahub::Factory contains Log4perl support to monitor conveyor belt operations.
 
-Invoke the perl script in `bin`.
+Note: This toolset is not a generic tool. It has been tailored towards the
+functional requirements of the Flemish Art Collection use case.
 
-    perl bin/dh-factory.pl \
-      --importer=Adlib \
-      --fixes=/path/to/catmandufixfile.fix \
-      --oimport file_name=/path/to/importfile.xml \
-      --ostore datahub_url="http://www.datahub.app" \
-      --ostore oauth_client_id=client_id \
-      --ostore oauth_client_secret=client_secret \
-      --ostore oauth_username=user \
-      --ostore oauth_password=password
+# COMMANDS
 
-## CLI
+## help COMMAND
 
-### Options
+Documentation about command line options.
 
-- `--importer`: select the importer to use. Supported importers are in `lib`and are of the form `$importer_name::Import.pm`. You only have to provide `$importer_name` By default `Adlib`is the only supported importer.
-- `--fixes`: location (path) of the file containing the fixes that have to be applied.
-- `--exporter`: select the exporter to use. Uses the same format as `--importer`, but only supports `Lido` Optional, if it isn't set, the default internal store is used. If it is set, the store isn't used.
-- `--oimport`: set `--importer`options like `--oimport _option_=_value_` Options are specific to the importer used (see below).
-- `--ostore`: set options for the default Datahub store. Uses the same syntax as `--oimport`.
-- `--oexport`: set options for `--exporter`using the same syntax as `--oimport`, but is only required if `--exporter`is used.
+## transport [OPTIONS]
 
-### Specific options
+Fetch data from a local or remote source, convert it to an exchange format and
+push the data to a Datahub instance.
 
-#### Importer
+--importer NAME
+   The importer which fetches data from a Collection Registration system.
+   Currently only "Adlib" and "TMS" are supported options.
 
-- `file_name`: path of the XML dump that the `--importer`will import from.
+--fixes PATH
+  The path to the Catmandu Fix files to transform the data.
 
-#### Exporter
+--oimport file_name=PATH
+  The path to a flat file containing data. This option is only relevant when
+  the input is an Adlib XML export file.
 
-- `file_name`: path of the file the `--exporter`will write to.
+--oimport db_user=VALUE
+  The database user. This option is only relevant when
+  the input is an TMS database.
 
-#### Store
+--oimport db_passowrd=VALUE
+  The database user password. This option is only relevant when
+  the input is an TMS database.
 
-- `datahub_url`. URL of the datahub (e.g. _http://www.datahub.app_).
-- `oauth_client_id`. OAuth2 client\_id.
-- `oauth_client_secret`. OAuth2 client\_secret.
-- `oauth_username`. OAuth2 username.
-- `oauth_password`. OAuth2 password.
+--oimport db_name=VALUE
+  The database name. This option is only relevant when
+  the input is an TMS database.
 
-# AUTHOR
+--oimport db_host=VALUE
+  The database host. This option is only relevant when
+  the input is an TMS database.
+
+--ostore datahub_url=VALUE
+  The URL to the datahub instance. This should be a FQDN ie. http://datahub.lan/
+
+--ostore oauth_client_id=VALUE
+  The client public ID. Used for OAuth authentication of the Datahub endpoint.
+
+--ostore oauth_client_secret=VALUE
+  The client secret passphrase. Used for OAuth authentication of the Datahub
+  endpoint.
+
+--ostore oauth_username=VALUE
+  The username of the Datahub user. Used for OAuth authentication of the Datahub
+  endpoint.
+
+--ostore oauth_password=VALUE
+  The password of the Datahub user. Used for OAuth authentication of the Datahub
+  endpoint.
+
+# AUTHORS
 
 - Pieter De Praetere <pieter@packed.be>
 - Matthias Vandermaesen <matthias.vandermaesen@vlaamsekunstcollectie.be>
 
 # COPYRIGHT
 
-Copyright 2016 - PACKED vzw
+Copyright 2016 - PACKED vzw, Vlaamse Kunstcollectie vzw
 
 # LICENSE
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ push the data to a Datahub instance.
 # EXAMPLE
 
 ```
-dhconveyor transport --importer=Adlib --fixes=myfixes.fix --oimport file_name=adlibexport.xml --datahub=http://datahub/ --ostore oauth_client_id=slightlylesssecretpublicid --ostore oauth_client_secret=supersecretsecretphrase --ostore oauth_password=password1 --ostore oauth_username=admin
+dhconveyor transport --importer=Adlib --fixes=myfixes.fix
+--oimport file_name=adlibexport.xml --datahub=http://datahub/
+--ostore oauth_client_id=slightlylesssecretpublicid --ostore oauth_client_secret=supersecretsecretphrase --ostore oauth_password=password1
+--ostore oauth_username=admin
 ```
 
 # AUTHORS

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NAME
+## NAME
 [![Build Status](https://travis-ci.org/thedatahub/Datahub-Factory.svg?branch=master)](https://travis-ci.org/thedatahub/Datahub-Factory)
 
 Datahub::Factory - A conveyor belt which transports data from a data source to

--- a/cpanfile
+++ b/cpanfile
@@ -7,6 +7,7 @@ requires 'Log::Any';
 requires 'Log::Log4perl';
 requires 'Moo';
 requires 'LWP::UserAgent';
+requires 'App::Cmd';
 
 requires 'WebService::Rackspace::CloudFiles', '1.10';
 requires 'Catmandu', '1.0304';

--- a/lib/Datahub/Factory.pm
+++ b/lib/Datahub/Factory.pm
@@ -1,7 +1,8 @@
 package Datahub::Factory;
 
-use strict;
-use 5.008_005;
+use strict; use warnings;
+use App::Cmd::Setup -app;
+
 our $VERSION = '0.01';
 
 1;

--- a/lib/Datahub/Factory.pm
+++ b/lib/Datahub/Factory.pm
@@ -13,98 +13,91 @@ __END__
 
 =head1 NAME
 
-Datahub::Factory - A conveyor belt which transforms data from an input format
-to an output format before pushing it to a Datahub instance.
+Datahub::Factory - A conveyor belt which transports data from a data source to
+a Datahub instance.
 
 =head1 SYNOPSIS
 
-Datahub::Factory consists of two elements: a library (C<Datahub::Factory>) and a conversion script (C<dh-factory.pl>).
+dhconveyor [ARGUMENTS] [OPTIONS]
 
 =head1 DESCRIPTION
 
-Datahub::Factory is a conveyor belt which does two things:
+Datahub::Factory is a command line conveyor belt which automates three tasks:
 
 =over
 
-=item Data is converted from an input format to an output format leveraging
-  Catmandu.
+=item Data is fetched automatically from a local or remote data source.
+=item Data is converted to an exchange format.
+=item The output is pushed to an operational Datahub instance.
 
-=item The output is pushed to an instance of the Datahub.
+= back
 
-=back
+Internally, Datahub::Factory uses Catmandu modules to transform the data, and
+implements the Datahub REST API. Datahub::Factory stitches the transformation
+and push tasks seamlessly together.
 
-Internally, Datahub::Factory uses Catmandu modules.
+Datahub::Factory contains Log4perl support to monitor conveyor belt operations.
 
-=head1 USAGE
+Note: This toolset is not a generic tool. It has been tailored towards the
+functional requirements of the Flemish Art Collection use case.
 
-Invoke the perl script in C<bin>.
+=head1 COMMANDS
 
+=head2 help COMMAND
 
-  perl bin/dh-factory.pl \
-    --importer=Adlib \
-    --fixes=/path/to/catmandufixfile.fix \
-    --oimport file_name=/path/to/importfile.xml \
-    --ostore datahub_url="http://www.datahub.app" \
-    --ostore oauth_client_id=client_id \
-    --ostore oauth_client_secret=client_secret \
-    --ostore oauth_username=user \
-    --ostore oauth_password=password
+Documentation about command line options.
 
-=head2 CLI
+=head2 transport [OPTIONS]
 
-=head3 Options
+Fetch data from a local or remote source, convert it to an exchange format and
+push the data to a Datahub instance.
 
-=over
+--importer NAME
+   The importer which fetches data from a Collection Registration system.
+   Currently only "Adlib" and "TMS" are supported options.
 
-=item C<--importer>: select the importer to use. Supported importers are in C<lib>and are of the form C<$importer_name::Import.pm>. You only have to provide C<$importer_name> By default C<Adlib>is the only supported importer.
+--fixes PATH
+  The path to the Catmandu Fix files to transform the data.
 
-=item C<--fixes>: location (path) of the file containing the fixes that have to be applied.
+--oimport file_name=PATH
+  The path to a flat file containing data. This option is only relevant when
+  the input is an Adlib XML export file.
 
-=item C<--exporter>: select the exporter to use. Uses the same format as C<--importer>, but only supports C<Lido> Optional, if it isn't set, the default internal store is used. If it is set, the store isn't used.
+--oimport db_user=VALUE
+  The database user. This option is only relevant when
+  the input is an TMS database.
 
-=item C<--oimport>: set C<--importer>options like C<--oimport _option_=_value_> Options are specific to the importer used (see below).
+--oimport db_passowrd=VALUE
+  The database user password. This option is only relevant when
+  the input is an TMS database.
 
-=item C<--ostore>: set options for the default Datahub store. Uses the same syntax as C<--oimport>.
+--oimport db_name=VALUE
+  The database name. This option is only relevant when
+  the input is an TMS database.
 
-=item C<--oexport>: set options for C<--exporter>using the same syntax as C<--oimport>, but is only required if C<--exporter>is used.
+--oimport db_host=VALUE
+  The database host. This option is only relevant when
+  the input is an TMS database.
 
-=back
+--ostore datahub_url=VALUE
+  The URL to the datahub instance. This should be a FQDN ie. http://datahub.lan/
 
-=head3 Specific options
+--ostore oauth_client_id=VALUE
+  The client public ID. Used for OAuth authentication of the Datahub endpoint.
 
-=head4 Importer
+--ostore oauth_client_secret=VALUE
+  The client secret passphrase. Used for OAuth authentication of the Datahub
+  endpoint.
 
-=over
+--ostore oauth_username=VALUE
+  The username of the Datahub user. Used for OAuth authentication of the Datahub
+  endpoint.
 
-=item C<file_name>: path of the XML dump that the C<--importer>will import from.
+--ostore oauth_password=VALUE
+  The password of the Datahub user. Used for OAuth authentication of the Datahub
+  endpoint.
 
-=back
-
-=head4 Exporter
-
-=over
-
-=item C<file_name>: path of the file the C<--exporter>will write to.
-
-=back
-
-=head4 Store
-
-=over
-
-=item C<datahub_url>. URL of the datahub (e.g. _http://www.datahub.app_).
-
-=item C<oauth_client_id>. OAuth2 client_id.
-
-=item C<oauth_client_secret>. OAuth2 client_secret.
-
-=item C<oauth_username>. OAuth2 username.
-
-=item C<oauth_password>. OAuth2 password.
-
-=back
-
-=head1 AUTHOR
+=head1 AUTHORS
 
 =over
 
@@ -116,7 +109,7 @@ Invoke the perl script in C<bin>.
 
 =head1 COPYRIGHT
 
-Copyright 2016 - PACKED vzw
+Copyright 2016 - PACKED vzw, Vlaamse Kunstcollectie vzw
 
 =head1 LICENSE
 

--- a/lib/Datahub/Factory/Command/transport.pm
+++ b/lib/Datahub/Factory/Command/transport.pm
@@ -159,3 +159,38 @@ sub execute {
 }
 
 1;
+
+=head1 NAME
+
+Datahub::Factory::Command::transport - Implements the 'transport' command.
+
+=head1 DESCRIPTION
+This command allows datamanagers to (a) fetch data from a (local) source (b)
+transform the data to LIDO using a fix (c) upload the LIDO transformed data to
+a Datahub instance.
+
+=head1 METHODS
+
+=head2 abstract
+
+ abstract();
+
+=head2 description
+
+ description();
+
+=head2 execute
+
+ execute();
+
+=head2 opt_spec
+
+ opt_spec();
+
+=head2 validate_args
+
+ validate_args();
+
+
+=cut
+

--- a/lib/Datahub/Factory/Command/transport.pm
+++ b/lib/Datahub/Factory/Command/transport.pm
@@ -31,6 +31,29 @@ sub opt_spec {
 	);
 }
 
+sub default_log4perl_config {
+    my $config = <<EOF;
+# STDERR
+log4perl.rootLogger=WARN,STDERR
+
+# Datahub-specific
+log4perl.category.datahub=INFO,STDERR
+
+# Catmandu
+
+# Output STDERR
+log4perl.appender.STDERR=Log::Log4perl::Appender::Screen
+log4perl.appender.STDERR.stderr=1
+log4perl.appender.STDERR.utf8=1
+
+log4perl.appender.STDERR.layout=PatternLayout
+
+log4perl.appender.STDERR.layout.ConversionPattern=%d [%P] - %p %l time=%r : %m%n
+
+EOF
+    \$config;
+}
+
 sub validate_args {
 	my ($self, $opt, $args) = @_;
 
@@ -95,7 +118,7 @@ sub execute {
 
   # Logger
   Log::Any::Adapter->set('Log4perl');
-  Log::Log4perl::init('conf/log4perl.conf');
+  Log::Log4perl::init(default_log4perl_config());
 
   my $logger = Log::Log4perl->get_logger('datahub');
 

--- a/lib/Datahub/Factory/Command/transport.pm
+++ b/lib/Datahub/Factory/Command/transport.pm
@@ -1,0 +1,161 @@
+package Datahub::Factory::Command::transport;
+
+use Datahub::Factory -command;
+
+use strict;
+use warnings;
+use diagnostics;
+
+use Module::Load;
+use Log::Any::Adapter;
+use Log::Log4perl;
+use Catmandu;
+use Catmandu::Sane;
+use Cwd ();
+
+use Data::Dumper;
+
+sub abstract { "Transport data from a data source to a datahub instance" }
+
+sub description { "Long description on blortex algorithm" }
+
+sub opt_spec {
+	return (
+		[ "importer|i=s",  "The importer" ],
+		[ "datahub|d=s",  "The datahub instance" ],
+		[ "exporter|e:s",  "The exporter"],
+		[ "fixes|f=s",  "Fixes"],
+		[ "oimport|oi=s%",  "import options"],
+		[ "oexport|oe:s%",  "export options"],
+		[ "ostore|os=s%",  "Store options"],
+	);
+}
+
+sub validate_args {
+	my ($self, $opt, $args) = @_;
+
+	if ( ! $opt->{importer} ) {
+		$self->usage_error("Importer is missing");
+	}
+
+	if ( ! $opt->{fixes} ) {
+		$self->usage_error("Fixes are missing");
+	}
+
+	if ( $opt->{importer} eq "Adlib" ) {
+		if ( ! $opt->{oimport}->{file_name} ) {
+			 $self->usage_error("Adlib: Import file is missing")
+		}
+	}
+
+	if ( $opt->{importer} eq "TMS" ) {
+		if ( ! $opt->{oimport}->{db_name} ) {
+			 $self->usage_error("TMS: database name is missing")
+		}
+
+		if ( ! $opt->{oimport}->{db_user} ) {
+			 $self->usage_error("TMS: database user is missing")
+		}
+
+		if ( ! $opt->{oimport}->{db_password} ) {
+			 $self->usage_error("TMS: database user password is missing")
+		}
+
+		if ( ! $opt->{oimport}->{db_host} ) {
+			 $self->usage_error("TMS: database host is missing")
+		}
+	}
+
+	if ( ! $opt->{ostore}->{datahub_url} ) {
+		$self->usage_error("Datahub: the URL to the datahub instance is missing")
+	}
+
+	if ( ! $opt->{ostore}->{oauth_client_id} ) {
+		$self->usage_error("Datahub OAUTH: the client id is missing")
+	}
+
+	if ( ! $opt->{ostore}->{oauth_client_secret} ) {
+		$self->usage_error("Datahub OAUTH: the client secret is missing")
+	}
+
+	if ( ! $opt->{ostore}->{oauth_username} ) {
+		$self->usage_error("Datahub OAUTH: the client username is missing")
+	}
+
+	if ( ! $opt->{ostore}->{oauth_password} ) {
+		$self->usage_error("Datahub OAUTH: the client passowrd is missing")
+	}
+
+	# no args allowed but options!
+	$self->usage_error("No args allowed") if @$args;
+}
+
+sub execute {
+  my ($self, $opt, $args) = @_;
+
+  # Logger
+  Log::Any::Adapter->set('Log4perl');
+  Log::Log4perl::init('conf/log4perl.conf');
+
+  my $logger = Log::Log4perl->get_logger('datahub');
+
+  # Load modules
+  my $store_module = 'Datahub::Factory::Store';
+  autoload $store_module;
+
+  my $fix_module = 'Datahub::Factory::Fix';
+  autoload $fix_module;
+
+  my $import_module = sprintf("Datahub::Factory::%s::Import", $opt->{importer});
+  autoload $import_module;
+
+  # my $export_module;
+  # if (defined($exporter) && $exporter ne '') {
+  #   $export_module = sprintf("Datahub::Factory::%s::Export", $exporter);
+  #   autoload $export_module;
+  # }
+
+  # Perform import/fix/store/export
+  my $catmandu_input = $import_module->new($opt->{oimport});
+  my $catmandu_fixer = $fix_module->new("file_name" => $opt->{fixes});
+  my $catmandu_output = $store_module->new($opt->{ostore});
+  # if (defined($exporter) && $exporter ne '') {
+  #   $catmandu_output = $export_module->new(%$export_options);
+  # }
+
+  $catmandu_fixer->fixer->fix($catmandu_input->importer)->each(sub {
+    my $item = shift;
+    my $item_id = $item->{'administrativeMetadata'}->{'recordWrap'}->{'recordID'}->[0]->{'_'};
+    try {
+        $catmandu_output->out->add($item);
+        $logger->info(sprintf("Adding item %s.", $item_id));
+  #  } catch_case [
+  #      'Catmandu::HTTPError' => sub {
+  #          my $msg = sprintf("Error while adding item %s: %s", $item_id, $_->message);
+  #          $logger->error($msg);
+  #      },
+  #      'Lido::XML::Error' => sub {
+  #          my $msg = sprintf("Error while adding item %s: %s", $item_id, $_->message);
+  #          $logger->error($msg);
+  #      },
+  # DOESN'T WORK
+  #      '*' => sub {
+  #          my $msg = sprintf("Error while adding item %s: %s", $item_id, $_->message);
+  #          $logger->error($msg);
+  #      }
+  #  ];
+    } catch {
+        my $msg;
+        if ($_->can('message')) {
+            $msg = sprintf("Error while adding item %s: %s", $item_id, $_->message);
+        } else {
+            $msg = sprintf("Error while adding item %s: %s", $item_id, $_);
+        }
+        $logger->error($msg);
+    };
+  });
+
+	print "Everything has been initialized.  (Not really.)\n";
+}
+
+1;

--- a/script/dh-factory.pl
+++ b/script/dh-factory.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!perl
 
 use strict;
 use warnings;
@@ -11,7 +11,7 @@ use Log::Log4perl;
 
 use Catmandu;
 use Catmandu::Sane;
-
+use Cwd ();
 
 # Logger
 Log::Any::Adapter->set('Log4perl');

--- a/script/dhconveyor
+++ b/script/dhconveyor
@@ -1,0 +1,4 @@
+#!perl
+
+use Datahub::Factory;
+Datahub::Factory->run;


### PR DESCRIPTION
This wires in App::Cmd support for bootstrapping the command. 

Here's how it works:

1. Clone the repo
2. Execute `./build && ./build install` to install the module to your active Perl installation (either system or plenv)
3. You can now run `dhconveyor` as a nice CLI command from anywhere. 

Pull request contains:

* Transport command
* Validation of passed options and arguments (no more nasty Perl fatal errors when executing)
* All the benefits of App::Cmd when a command is run

Todo:

* Exporter needs to be implemented separately, which is nice
* Separate Log4perl support from the transport command, bring it to the bootstrap level (See: Catmandu project)
