### PR TITLE
Fixes #6 Refurbish logging

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,20 +2,22 @@ requires 'perl', '5.008005';
 
 # requires 'Some::Module', 'VERSION';
 
-requires 'Module::Load';
-requires 'Log::Any';
-requires 'Log::Log4perl';
-requires 'Moo';
-requires 'LWP::UserAgent';
 requires 'App::Cmd';
-
-requires 'WebService::Rackspace::CloudFiles', '1.10';
 requires 'Catmandu', '1.0304';
-
+requires 'Catmandu::LIDO';
 requires 'Catmandu::Store::Datahub';
 requires 'Catmandu::Store::Resolver';
 requires 'Lido::XML';
-requires 'Catmandu::LIDO';
+requires 'Log::Any';
+requires 'Log::Log4perl';
+requires 'LWP::UserAgent';
+requires 'Module::Load';
+requires 'Moo';
+requires 'MooX::Aliases';
+requires 'MooX::Role::Logger';
+requires 'namespace::clean';
+requires 'Sub::Exporter';
+requires 'WebService::Rackspace::CloudFiles', '1.10';
 
 on test => sub {
     requires 'Test::More', '0.96';

--- a/lib/Datahub/Factory.pm
+++ b/lib/Datahub/Factory.pm
@@ -1,9 +1,37 @@
 package Datahub::Factory;
 
-use strict; use warnings;
-use App::Cmd::Setup -app;
-
 our $VERSION = '0.01';
+
+use Datahub::Factory::Sane;
+
+use Datahub::Factory::Env;
+use namespace::clean;
+use Sub::Exporter::Util qw(curry_method);
+use Sub::Exporter -setup => {
+    exports => [
+        log              => curry_method,
+    ],
+    collectors => {'-load' => \'_import_load', ':load' => \'_import_load',},
+};
+
+sub _import_load {
+  my $class = shift;
+  my $env   = Datahub::Factory::Env->new();
+  $class->_env($env);
+  $class;
+}
+
+sub _env {
+    my ($class, $env) = @_;
+    state $loaded_env;
+    $loaded_env = $env if defined $env;
+    $loaded_env
+        ||= Datahub::Factory::Env->new();
+}
+
+sub log {
+	$_[0]->_env->log;
+}
 
 1;
 __END__

--- a/lib/Datahub/Factory/CLI.pm
+++ b/lib/Datahub/Factory/CLI.pm
@@ -1,0 +1,83 @@
+package Datahub::Factory::CLI;
+
+use Datahub::Factory::Sane;
+
+use Datahub::Factory;
+use Log::Any::Adapter;
+use Log::Log4perl;
+use namespace::clean;
+
+use parent qw(App::Cmd);
+
+sub default_command {'commands'}
+
+sub plugin_search_path {'Datahub::Factory::Command'}
+
+sub global_opt_spec {
+    (['logging|L:i', ""]);
+}
+
+sub default_log4perl_config {
+    my $level    = shift // 'DEBUG';
+    my $appender = shift // 'STDERR';
+
+    my $config = <<EOF;
+log4perl.rootLogger=$level,$appender
+log4perl.category.datahub=$level,$appender
+
+log4perl.appender.STDOUT=Log::Log4perl::Appender::Screen
+log4perl.appender.STDOUT.stderr=0
+log4perl.appender.STDOUT.utf8=1
+
+log4perl.appender.STDOUT.layout=PatternLayout
+log4perl.appender.STDOUT.layout.ConversionPattern=%d [%P] - %p %l %M time=%r : %m%n
+
+log4perl.appender.STDERR=Log::Log4perl::Appender::Screen
+log4perl.appender.STDERR.stderr=1
+log4perl.appender.STDERR.utf8=1
+
+log4perl.appender.STDERR.layout=PatternLayout
+log4perl.appender.STDERR.layout.ConversionPattern=%d [%P] - %p %l time=%r : %m%n
+
+EOF
+    \$config;
+}
+
+sub setup_logging {
+  my %LEVELS = (1 => 'WARN', 2 => 'INFO', 3 => 'DEBUG');
+  my $logging = shift;
+  my $level  = $LEVELS{$logging} // 'WARN';
+
+  Log::Log4perl::init(default_log4perl_config($level, 'STDERR'));
+  Log::Any::Adapter->set('Log4perl');
+
+  Datahub::Factory->log->warn(
+    "Logger activated - level $level"
+  );
+}
+
+sub run {
+  my ($class) = @_;
+  my ($global_opts, $argv)
+    = $class->_process_args([@ARGV],
+      $class->_global_option_processing_params);
+
+  # Setup logging
+  if (exists $global_opts->{logging}) {
+    setup_logging($global_opts->{logging} // 1);
+  }
+
+  my $self = ref $class ? $class : $class->new;
+  $self->set_global_options($global_opts);
+
+  my ($cmd, $opt, @args) = $self->prepare_command(@$argv);
+
+  # ...and then run it
+  $self->execute_command($cmd, $opt, @args);
+
+  return 1;
+}
+
+1;
+
+__END__

--- a/lib/Datahub/Factory/CLI.pm
+++ b/lib/Datahub/Factory/CLI.pm
@@ -81,3 +81,14 @@ sub run {
 1;
 
 __END__
+
+=head1 NAME
+
+Datahub::Factory::CLI - The App::Cmd class for the Datahub::Factory aplpication
+
+=head1 SEE ALSO
+
+L<factory>
+
+=cut
+

--- a/lib/Datahub/Factory/Cmd.pm
+++ b/lib/Datahub/Factory/Cmd.pm
@@ -1,0 +1,10 @@
+package Datahub::Factory::Cmd;
+
+use Datahub::Factory::Sane;
+
+use parent qw(App::Cmd::Command);
+use namespace::clean;
+
+1;
+
+__END__

--- a/lib/Datahub/Factory/Cmd.pm
+++ b/lib/Datahub/Factory/Cmd.pm
@@ -8,3 +8,21 @@ use namespace::clean;
 1;
 
 __END__
+
+=head1 NAME
+
+Datahub::Factory::Cmd - A base class for extending the Datahub Factory command
+line
+
+=head1 SYNOPSIS
+
+=head1 DESCRIPTION
+
+Datahub::Factory::Cmd is a base class to extend the commands that can be
+provided for the 'dhconveyor' command line tools.  New dhconveyor commands
+should be defined in the Datahub::Factory::Command namespace and extend
+Datahub::Factory::Cmd.
+
+=head1 METHODS
+
+=cut

--- a/lib/Datahub/Factory/Command/transport.pm
+++ b/lib/Datahub/Factory/Command/transport.pm
@@ -1,19 +1,12 @@
 package Datahub::Factory::Command::transport;
 
-use Datahub::Factory -command;
+use Datahub::Factory::Sane;
 
-use strict;
-use warnings;
-use diagnostics;
+use parent 'Datahub::Factory::Cmd';
 
 use Module::Load;
-use Log::Any::Adapter;
-use Log::Log4perl;
 use Catmandu;
-use Catmandu::Sane;
-use Cwd ();
-
-use Data::Dumper;
+use namespace::clean;
 
 sub abstract { "Transport data from a data source to a datahub instance" }
 
@@ -29,29 +22,6 @@ sub opt_spec {
 		[ "oexport|oe:s%",  "export options"],
 		[ "ostore|os=s%",  "Store options"],
 	);
-}
-
-sub default_log4perl_config {
-    my $config = <<EOF;
-# STDERR
-log4perl.rootLogger=WARN,STDERR
-
-# Datahub-specific
-log4perl.category.datahub=INFO,STDERR
-
-# Catmandu
-
-# Output STDERR
-log4perl.appender.STDERR=Log::Log4perl::Appender::Screen
-log4perl.appender.STDERR.stderr=1
-log4perl.appender.STDERR.utf8=1
-
-log4perl.appender.STDERR.layout=PatternLayout
-
-log4perl.appender.STDERR.layout.ConversionPattern=%d [%P] - %p %l time=%r : %m%n
-
-EOF
-    \$config;
 }
 
 sub validate_args {
@@ -117,8 +87,8 @@ sub execute {
   my ($self, $opt, $args) = @_;
 
   # Logger
-  Log::Any::Adapter->set('Log4perl');
-  Log::Log4perl::init(default_log4perl_config());
+  # Log::Any::Adapter->set('Log4perl');
+  # Log::Log4perl::init(default_log4perl_config());
 
   my $logger = Log::Log4perl->get_logger('datahub');
 
@@ -182,6 +152,8 @@ sub execute {
 }
 
 1;
+
+__END__
 
 =head1 NAME
 

--- a/lib/Datahub/Factory/Command/transport.pm
+++ b/lib/Datahub/Factory/Command/transport.pm
@@ -6,6 +6,7 @@ use parent 'Datahub::Factory::Cmd';
 
 use Module::Load;
 use Catmandu;
+use Datahub::Factory;
 use namespace::clean;
 
 sub abstract { "Transport data from a data source to a datahub instance" }
@@ -86,11 +87,7 @@ sub validate_args {
 sub execute {
   my ($self, $opt, $args) = @_;
 
-  # Logger
-  # Log::Any::Adapter->set('Log4perl');
-  # Log::Log4perl::init(default_log4perl_config());
-
-  my $logger = Log::Log4perl->get_logger('datahub');
+  my $logger = Datahub::Factory->log;
 
   # Load modules
   my $store_module = 'Datahub::Factory::Store';

--- a/lib/Datahub/Factory/Env.pm
+++ b/lib/Datahub/Factory/Env.pm
@@ -10,3 +10,14 @@ with 'Datahub::Factory::Logger';
 1;
 
 __END__
+
+=head1 NAME
+
+Datahub::Factory::Env - A Datahub::Factory configuration file loader
+
+=head1 SYNOPSIS
+
+=head1 DESCRIPTION
+
+=cut
+

--- a/lib/Datahub/Factory/Env.pm
+++ b/lib/Datahub/Factory/Env.pm
@@ -1,0 +1,12 @@
+package Datahub::Factory::Env;
+
+use Datahub::Factory::Sane;
+
+use Moo;
+use namespace::clean;
+
+with 'Datahub::Factory::Logger';
+
+1;
+
+__END__

--- a/lib/Datahub/Factory/Fix.pm
+++ b/lib/Datahub/Factory/Fix.pm
@@ -1,11 +1,12 @@
 package Datahub::Factory::Fix;
 
+use Datahub::Factory::Sane;
+
 use Moo;
 use Catmandu;
-use strict;
+use namespace::clean;
 
 has file_name => (is => 'ro', required => 1);
-
 has fixer => (is => 'lazy');
 
 sub _build_fixer {

--- a/lib/Datahub/Factory/Logger.pm
+++ b/lib/Datahub/Factory/Logger.pm
@@ -1,0 +1,15 @@
+package Datahub::Factory::Logger;
+
+use Datahub::Factory::Sane;
+
+use Moo::Role;
+use MooX::Aliases;
+use namespace::clean;
+
+with 'MooX::Role::Logger';
+
+alias log => '_logger';
+
+1;
+
+__END__

--- a/lib/Datahub/Factory/Logger.pm
+++ b/lib/Datahub/Factory/Logger.pm
@@ -13,3 +13,69 @@ alias log => '_logger';
 1;
 
 __END__
+
+=head1 NAME
+
+Datahub::Factory::Logger - A role for classes that need logging capabilities
+
+=head1 SYNOPSIS
+
+    package MyApp::View;
+    use Moo;
+
+    with 'Datahub::Factory::Logger';
+
+    sub something {
+        my ($self) = @_;
+        $self->log->debug("started bar"); # logs with default class catergory "MyApp::View"
+        $self->log->error("started bar");
+    }
+
+=head1 DESCRIPTION
+
+A logging role building a very lightweight wrapper to L<Log::Any>.  Connecting
+a Log::Any::Adapter should be performed prior to logging the first log message,
+otherwise nothing will happen, just like with Log::Any.
+
+The logger needs to be setup before using the logger, which could happen in the main application:
+
+    package main;
+    use Log::Any::Adapter;
+    use Log::Log4perl;
+
+    Log::Any::Adapter->set('Log4perl');
+    Log::Log4perl::init('./log4perl.conf');
+
+    my $app = MyApp::View->new;
+    $app->something();  # will print debug and error messages
+
+with log4perl.conf like:
+
+    log4perl.rootLogger=DEBUG,OUT
+    log4perl.appender.OUT=Log::Log4perl::Appender::Screen
+    log4perl.appender.OUT.stderr=1
+    log4perl.appender.OUT.utf8=1
+
+    log4perl.appender.OUT.layout=PatternLayout
+    log4perl.appender.OUT.layout.ConversionPattern=%d [%P] - %p %l time=%r : %m%n
+
+See L<Log::Log4perl> for more configuration options and selecting which messages
+to log and which not.
+
+=head1 DATAHUB FACTORY COMMAND LINE
+
+When using the L<dhconveyor> command line, the logger can be activated using the
+-D option on all Datahub Factory commands:
+
+     $ dhconveyor -D transport ...
+
+=head1 METHODS
+
+L<Log::Any>
+
+=head1 ACKNOWLEDGMENTS
+
+Code and documentation blatantly stolen from C<Catmandu> who got it from
+C<MooX::Log::Any>.
+
+=cut

--- a/lib/Datahub/Factory/Sane.pm
+++ b/lib/Datahub/Factory/Sane.pm
@@ -26,11 +26,11 @@ __END__
 
 =head1 NAME
 
-Catmandu::Sane - Package boilerplate
+Datahub::Factory::Sane - Package boilerplate
 
 =head1 SYNOPSIS
 
-    use Catmandu::Sane;
+    use Datahub::Factory::Sane;
 
     # Provides all the 5.10 features.
     say("what");
@@ -49,12 +49,6 @@ Catmandu::Sane - Package boilerplate
     try {
     } catch {};
 
-    # Provides
-    Catmandu::Error->throw("error");
-    Catmandu::BadVal->throw("eek val");
-    Catmandu::BadArg->throw("eek arg");
-    Catmandu::NotImplemented->throw("can't do that!");
-
 =head1 DESCRIPTION
 
 Package boilerplate equivalent to:
@@ -66,6 +60,5 @@ Package boilerplate equivalent to:
     use IO::File ();
     use IO::Handle ();
     use Try::Tiny::ByClass;
-    use Catmandu::Error;
 
 =cut

--- a/lib/Datahub/Factory/Sane.pm
+++ b/lib/Datahub/Factory/Sane.pm
@@ -1,0 +1,71 @@
+package Datahub::Factory::Sane;
+
+use strict;
+use warnings;
+
+use feature ();
+use utf8;
+use IO::File ();
+use IO::Handle ();
+use Try::Tiny::ByClass;
+
+sub import {
+    my $pkg = caller;
+    strict->import;
+    warnings->import;
+    feature->import(qw(:5.10));
+    utf8->import;
+    Try::Tiny::ByClass->export_to_level(1, $pkg);
+}
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Catmandu::Sane - Package boilerplate
+
+=head1 SYNOPSIS
+
+    use Catmandu::Sane;
+
+    # Provides all the 5.10 features.
+    say("what");
+    given($foo) {
+        when(1)     { say "1" }
+        when([2,3]) { say "2 or 3" }
+        when(/abc/) { say "has abc" }
+        default     { none of the above }
+    }
+    sub next_id{
+      state $id;
+      ++$id;
+    }
+
+    # Provides try/catch[/finally] try/catch_case[/finally]
+    try {
+    } catch {};
+
+    # Provides
+    Catmandu::Error->throw("error");
+    Catmandu::BadVal->throw("eek val");
+    Catmandu::BadArg->throw("eek arg");
+    Catmandu::NotImplemented->throw("can't do that!");
+
+=head1 DESCRIPTION
+
+Package boilerplate equivalent to:
+
+    use strict;
+    use warnings;
+    use feature qw(:5.10);
+    use utf8;
+    use IO::File ();
+    use IO::Handle ();
+    use Try::Tiny::ByClass;
+    use Catmandu::Error;
+
+=cut

--- a/lib/Datahub/Factory/Store.pm
+++ b/lib/Datahub/Factory/Store.pm
@@ -1,8 +1,10 @@
 package Datahub::Factory::Store;
 
+use Datahub::Factory::Sane;
+
 use Moo;
 use Catmandu;
-use strict;
+use namespace::clean;
 
 has datahub_url         => (is => 'ro', required => 1);
 has datahub_format      => (is => 'ro', default => sub { return 'LIDO'; });

--- a/script/dhconveyor
+++ b/script/dhconveyor
@@ -1,4 +1,5 @@
 #!perl
 
-use Datahub::Factory;
-Datahub::Factory->run;
+use Datahub::Factory::CLI;
+
+Datahub::Factory::CLI->run;


### PR DESCRIPTION
This pull request yanks out the need of a logger setup for each discrete command and moves it to a global command bootstrap level.

A few notes:

* CLI.pm extends the `App::Cmd` class. This is where app specific logic is jacked into the App::Cmd framework.
* Factory.pm contains glue code to load environment based configuration. This part is incomplete. The class only has what is needed to wire in a log adapter implemented through `Datahub::Factory::Logger`.